### PR TITLE
Improved MealType Logic, Consistent UserFactory Calls in tests, and Comprehensive GenerateRecipeTest

### DIFF
--- a/src/entity/MealType.java
+++ b/src/entity/MealType.java
@@ -17,7 +17,7 @@ public enum MealType {
 
     public static MealType fromString(String stringValue) {
         for (MealType mealType : MealType.values()) {
-            if (mealType.name().equals(stringValue)) {
+            if (mealType.toString().equals(stringValue)) {
                 return mealType;
             }
         }

--- a/test/entity/MealTypeTest.java
+++ b/test/entity/MealTypeTest.java
@@ -1,0 +1,40 @@
+package entity;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MealTypeTest {
+    private MealType breakfast;
+    private MealType lunch;
+    private MealType dinner;
+
+    @BeforeEach
+    void init() {
+        breakfast = MealType.BREAKFAST;
+        lunch = MealType.LUNCH;
+        dinner = MealType.DINNER;
+    }
+
+    @Test
+    void toStringTest() {
+        assertEquals("Breakfast", breakfast.toString());
+        assertEquals("Lunch", lunch.toString());
+        assertEquals("Dinner", dinner.toString());
+    }
+
+    @Test
+    void fromStringTest() {
+        assertEquals(MealType.BREAKFAST, MealType.fromString("Breakfast"));
+        assertEquals(MealType.LUNCH, MealType.fromString("Lunch"));
+        assertEquals(MealType.DINNER, MealType.fromString("Dinner"));
+    }
+
+    @Test
+    void fromStringNullTest() {
+        assertEquals(null, MealType.fromString("Breakfastt"));
+        assertEquals(null, MealType.fromString("Luncch"));
+        assertEquals(null, MealType.fromString("Dinneer"));
+    }
+}

--- a/test/interface_adapters/generate_recipe/GenerateRecipeTest.java
+++ b/test/interface_adapters/generate_recipe/GenerateRecipeTest.java
@@ -1,0 +1,100 @@
+package interface_adapters.generate_recipe;
+
+import api.edamam.GenerateRecipeAPICaller;
+import app.GenerateRecipeUseCaseFactory;
+import data_access.FileRecipeDataAccessObject;
+import entity.Recipe;
+import entity.RecipeFactory;
+import interface_adapters.ViewManagerModel;
+import interface_adapters.after_generated_recipe.AfterGeneratedRecipeViewModel;
+import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import use_case.generate_recipe.GenerateRecipeDataAccessInterface;
+import use_case.generate_recipe.GenerateRecipeInputData;
+
+public class GenerateRecipeTest {
+    private ViewManagerModel viewManagerModel;
+    private AfterGeneratedRecipeViewModel afterGeneratedRecipeViewModel;
+    private GenerateRecipeDataAccessInterface recipeDAO;
+    private GenerateRecipeController controller;
+
+    @BeforeEach
+    void init() {
+        viewManagerModel = new ViewManagerModel();
+        afterGeneratedRecipeViewModel = new AfterGeneratedRecipeViewModel();
+        GenerateRecipeViewModel generateRecipeViewModel = new GenerateRecipeViewModel();
+        recipeDAO = new FileRecipeDataAccessObject(new RecipeFactory());
+        controller = GenerateRecipeUseCaseFactory.createGenerateUseCase(viewManagerModel, afterGeneratedRecipeViewModel, generateRecipeViewModel, recipeDAO);
+    }
+
+    /**
+     * Test the use case of generating a recipe (take the expected recipe from afterGeneratedRecipeViewModel set by presenter)
+     * Therefore, this test is dependent on the correctness of the presenter
+     */
+    @Test
+    public void testGenerateRecipe() {
+        // make the input data
+        String q = "chicken";
+        String[] diet = {"balanced"};
+        String[] health = {"alcohol-free"};
+        String[] cuisineType = {"Chinese", "Japanese", "American"};
+        String[] mealType = {"Lunch", "Dinner"};
+        String minCalories = "100";
+        String maxCalories = "1000";
+        String maxPreparationTime = "100";
+
+        // execute the use case
+        controller.execute(q, diet, health, cuisineType, mealType, minCalories, maxCalories, maxPreparationTime);
+
+        // check that the recipe saved is correct
+        Recipe expectedRecipe = afterGeneratedRecipeViewModel.getState().getRecipe();
+        Assertions.assertNotNull(expectedRecipe);
+
+        Recipe actualSavedRecipe = recipeDAO.getRecipe(expectedRecipe.getLabel());
+        Assertions.assertNotNull(actualSavedRecipe);
+
+        Assertions.assertEquals(expectedRecipe.getLabel(), actualSavedRecipe.getLabel());
+        Assertions.assertEquals(expectedRecipe.getRecipeUrl(), actualSavedRecipe.getRecipeUrl());
+        Assertions.assertEquals(expectedRecipe.getImagePath(), actualSavedRecipe.getImagePath());
+        Assertions.assertEquals(expectedRecipe.getCalories(), actualSavedRecipe.getCalories());
+        Assertions.assertEquals(expectedRecipe.getIngredients(), actualSavedRecipe.getIngredients());
+        Assertions.assertEquals(expectedRecipe.getPreparationTime(), actualSavedRecipe.getPreparationTime());
+        Assertions.assertEquals(expectedRecipe.getYield(), actualSavedRecipe.getYield());
+
+        // check other expected things (from the presenter)
+        Assertions.assertEquals(viewManagerModel.getActiveView(), afterGeneratedRecipeViewModel.getViewName());
+    }
+
+    @Test
+    public void testGenerateRecipeDataAccess() {
+        // create the data access object
+        GenerateRecipeDataAccessInterface recipeDAO = new FileRecipeDataAccessObject(new RecipeFactory());
+
+        // make the input data
+        String q = "chicken";
+        String[] diet = {"balanced"};
+        String[] health = {"alcohol-free"};
+        String[] cuisineType = {"Chinese", "Japanese", "American"};
+        String[] mealType = {"Lunch", "Dinner"};
+        String minCalories = "100";
+        String maxCalories = "1000";
+        String maxPreparationTime = "100";
+
+        Recipe generatedRecipe = GenerateRecipeAPICaller.call(new GenerateRecipeInputData(q, diet, health, cuisineType, mealType, minCalories + "-" + maxCalories, "0-" + maxPreparationTime)).getRecipe();
+        recipeDAO.save(generatedRecipe);
+
+        // check that the recipe saved is correct
+        Recipe actualSavedRecipe = recipeDAO.getRecipe(generatedRecipe.getLabel());
+
+        Assertions.assertNotNull(actualSavedRecipe);
+        Assertions.assertEquals(generatedRecipe.getLabel(), actualSavedRecipe.getLabel());
+        Assertions.assertEquals(generatedRecipe.getRecipeUrl(), actualSavedRecipe.getRecipeUrl());
+        Assertions.assertEquals(generatedRecipe.getImagePath(), actualSavedRecipe.getImagePath());
+        Assertions.assertEquals(generatedRecipe.getCalories(), actualSavedRecipe.getCalories());
+        Assertions.assertEquals(generatedRecipe.getIngredients(), actualSavedRecipe.getIngredients());
+        Assertions.assertEquals(generatedRecipe.getPreparationTime(), actualSavedRecipe.getPreparationTime());
+        Assertions.assertEquals(generatedRecipe.getYield(), actualSavedRecipe.getYield());
+    }
+}

--- a/test/use_case/add_favorite_recipe/AddFavoriteRecipeInteractorTest.java
+++ b/test/use_case/add_favorite_recipe/AddFavoriteRecipeInteractorTest.java
@@ -1,5 +1,6 @@
 package use_case.add_favorite_recipe;
 
+import data_access.FilePlannerDataAccessObject;
 import data_access.FileRecipeDataAccessObject;
 import data_access.FileUserDataAccessObject;
 import entity.*;
@@ -20,6 +21,7 @@ public class AddFavoriteRecipeInteractorTest {
         AddFavoriteRecipeUserDataAccessInterface userDAO;
 
         recipeDAO = new FileRecipeDataAccessObject(recipeFactory);
+        FilePlannerDataAccessObject plannerDAO = new FilePlannerDataAccessObject(new PlannerFactory(), recipeDAO);
         try {
             userDAO = new FileUserDataAccessObject(userFactory);
         } catch (IOException e) {
@@ -27,7 +29,7 @@ public class AddFavoriteRecipeInteractorTest {
         }
 
 
-        User user1 = userFactory.create("Christoffer", "ganteng", "christoffer", 18, "Man", 170, 68);
+        User user1 = userFactory.create("Christoffer", "ganteng", "christoffer", 18, "Man", 170, 68, plannerDAO.getPlanner("Christoffer"));
         userDAO.save(user1);
 
         Recipe recipe = new Recipe("Asian-Style Chicken and Rice",
@@ -61,12 +63,14 @@ public class AddFavoriteRecipeInteractorTest {
         AddFavoriteRecipeUserDataAccessInterface userDAO;
 
         recipeDAO = new FileRecipeDataAccessObject(recipeFactory);
+        FilePlannerDataAccessObject plannerDAO = new FilePlannerDataAccessObject(new PlannerFactory(), recipeDAO);
+
         try {
             userDAO = new FileUserDataAccessObject(userFactory);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        User user1 = userFactory.create("Janis", "joplin", "Jantod", 38, "Man", 90, 168);
+        User user1 = userFactory.create("Janis", "joplin", "Jantod", 38, "Man", 90, 168, plannerDAO.getPlanner("Janis"));
         userDAO.save(user1);
 
         Recipe recipe = new Recipe("Asian-Style Chicken and Rice",

--- a/test/use_case/add_friend/AddFriendInteractorTest.java
+++ b/test/use_case/add_friend/AddFriendInteractorTest.java
@@ -2,6 +2,7 @@ package use_case.add_friend;
 
 import data_access.InMemoryUserDataAccessObject;
 import entity.CommonUserFactory;
+import entity.PlannerFactory;
 import entity.User;
 import entity.UserFactory;
 import org.junit.jupiter.api.Test;
@@ -15,8 +16,9 @@ public class AddFriendInteractorTest{
         AddFriendUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         UserFactory factory = new CommonUserFactory();
-        User user1 = factory.create("Christoffer", "ganteng", "christoffer", 18, "Man", 170, 68);
-        User user2 = factory.create("Janis", "jelek", "janis", 19, "Woman", 175, 90);
+        PlannerFactory plannerFactory = new PlannerFactory();
+        User user1 = factory.create("Christoffer", "ganteng", "christoffer", 18, "Man", 170, 68, plannerFactory.create("Christoffer"));
+        User user2 = factory.create("Janis", "jelek", "janis", 19, "Woman", 175, 90, plannerFactory.create("Janis"));
         ((InMemoryUserDataAccessObject) userRepository).save(user1);
         ((InMemoryUserDataAccessObject) userRepository).save(user2);
         AddFriendOutputBoundary successPresenter = new AddFriendOutputBoundary() {
@@ -41,7 +43,9 @@ public class AddFriendInteractorTest{
         AddFriendUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         UserFactory factory = new CommonUserFactory();
-        User user1 = factory.create("Christoffer", "ganteng", "christoffer", 18, "Man", 170, 68);
+        PlannerFactory plannerFactory = new PlannerFactory();
+        User user1 = factory.create("Christoffer", "ganteng", "christoffer", 18, "Man", 170, 68, plannerFactory.create("Christoffer"));
+        ((InMemoryUserDataAccessObject) userRepository).save(user1);
         ((InMemoryUserDataAccessObject) userRepository).save(user1);
         AddFriendOutputBoundary failurePresenter = new AddFriendOutputBoundary() {
 
@@ -65,8 +69,9 @@ public class AddFriendInteractorTest{
         AddFriendUserDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         UserFactory factory = new CommonUserFactory();
-        User user1 = factory.create("Christoffer", "ganteng", "christoffer", 18, "Man", 170, 68);
-        User user2 = factory.create("Janis", "jelek", "janis", 19, "Woman", 175, 90);
+        PlannerFactory plannerFactory = new PlannerFactory();
+        User user1 = factory.create("Christoffer", "ganteng", "christoffer", 18, "Man", 170, 68, plannerFactory.create("Christoffer"));
+        User user2 = factory.create("Janis", "jelek", "janis", 19, "Woman", 175, 90, plannerFactory.create("Janis"));
         ((InMemoryUserDataAccessObject) userRepository).save(user1);
         ((InMemoryUserDataAccessObject) userRepository).save(user2);
         userRepository.addFriend("Christoffer", "Janis");

--- a/test/use_case/after_generated_recipe/AfterGeneratedRecipeTest.java
+++ b/test/use_case/after_generated_recipe/AfterGeneratedRecipeTest.java
@@ -18,13 +18,14 @@ public class AfterGeneratedRecipeTest {
         RecipeFactory recipeFactory = new RecipeFactory();
         FileUserDataAccessObject userDAO;
         FileRecipeDataAccessObject recipeDAO = new FileRecipeDataAccessObject(recipeFactory);
+        PlannerFactory plannerFactory = new PlannerFactory();
 
         try {
             userDAO = new FileUserDataAccessObject(userFactory);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        User user = userFactory.create("Budi", "Andi", "Budi anak bu desi", 8, "Man", 180, 68);
+        User user = userFactory.create("Budi", "Andi", "Budi anak bu desi", 8, "Man", 180, 68, plannerFactory.create("Budi"));
         Recipe recipe = recipeFactory.create("Asian-Style Chicken and Rice",
                 "https://www.marthastewart.com/973886/asian-style-chicken-and-rice",
                 "https://edamam-product-images.s3.amazonaws.com/web-img/735/7352082497426f599a8b37a9326ec803.jpg?X-Amz-Security-Token=IQoJb3JpZ2luX2VjEJf%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJGMEQCIEvEOVhkYVEQsybGojXt4F952FlDEqgyE1GrrrMh1FK6AiB1vkWiXqQuuJAE8IZMrEOJHHh9rZgZnH2B910pIzCOSirBBQjg%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAAaDDE4NzAxNzE1MDk4NiIMrILV0dcHsqFs1%2FXkKpUF2YVdJB28f4Zf%2B1B10899LNV01iGDUEw3udDT2Jk63XQA12lvwyCN3jhHXRYUgBsrn4D%2BcLz7Xduy8oRWfIMCLYcdOzg%2Ffni8%2F%2BvYMHcC4AXbaLsRkaUS8UcA0ICpac85OGg8ns53%2BUkoKn1UeV1cry1Q4572n8DfsMbB2%2F7VJnF%2Bugdz7HnOKoLq9Cmnbki5VV2%2Br0vgdx3Hrfj0AYwIjWl15Hqh0vClgHko8H4n5X%2BdwqgCstMDJGrTcNcl0dcwbP82DQ7ZRRpmupsEuhZ8fwM8cqUsCDRLU94VIR10WFhDww%2FHbuSceq2vr9nJzhyqUbEnxj8Fz3QlTNgvqdF1rNM%2Bax4z6C1tPHbpa07TeA2PqMZc0bb2HhA0pYUBV4vvvGZTI02fWnRmHNo7xOOrB5IeWEZulQWHSFZXos3ID15T6dGwmY5hvDmJdWt7WqFLoiM%2FXNZk%2BAejT7z65iEUPGW4ZM0oXzq%2B9KbFWtsiMaA%2BFKspRXTY9KI3DaL0Epy2kIZmk7X%2B69AhdiCVhvZ%2Fx6G05FGMMY0dFy3Nc9tiMP0rTZyZDNrj6Ml2FoHNUt4RGjqjRxiI9tQ3k7LtDQnK5Gol83OrL18JZ%2BvCvMk7pnWQTTxlFgCOL2admpeUZq5EuPhLE5pkNpMVNKHu5Tv%2BIjwAzyvdu3TbhCjDmRjLYex4i9j98fufQwN2G1TgaiWaz5qJFfetXrqH3hx9h6t4GrS51wAMV9F%2FWwxgwytv4OFAp1dndNi8oLOkVLW5xms097b8Ry3CdUyI%2FMyl3CNcECqwKwNg7cNch4Jx%2FKpNJAsyjRtSxtUNSk31EaubZx6Pe4TFTqUxfH%2BC1PXwGy88NUz9G744CFJFH61ex6oKmHXQQHbN8DCPo%2BqqBjqyAYJiAMpLhcyOVCGwXHWIgswwmaavxRmlHqsE9ITdyHCFscgSaz1yO5mKRnhh5dHZxL72QZXUzrfTxoYoRTL1mD%2F9TXwnZyitm%2BFPL%2FPUBLdj05%2BHgbkqFCZo5n9Kcr2hYQfQh7sifc0wrDpkJy2YFig%2FJTR4iqJI4Z02oXcvKovJzJiXZZUD7KBF%2FijLTqAHUowC0z%2FgF5Cgn6%2Ff1V9VfeeDNo0N3svgR%2FFN4Eq99ln8bjE%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20231119T232629Z&X-Amz-SignedHeaders=host&X-Amz-Expires=3600&X-Amz-Credential=ASIASXCYXIIFIDBYH6EZ%2F20231119%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=f76f87ef51e9a879b462b85b97b3b6e18ef37866647964292b5ee17ae540278c",

--- a/test/use_case/delete_favorite_recipe/DeleteFavoriteRecipeInteractorTest.java
+++ b/test/use_case/delete_favorite_recipe/DeleteFavoriteRecipeInteractorTest.java
@@ -19,6 +19,7 @@ public class DeleteFavoriteRecipeInteractorTest {
         RecipeFactory recipeFactory = new RecipeFactory();
         FileRecipeDataAccessObject recipeDataAccessObject;
         DeleteFavoriteRecipeDataAccessInterface userDataAccessObject;
+        PlannerFactory plannerFactory = new PlannerFactory();
 
         recipeDataAccessObject = new FileRecipeDataAccessObject(recipeFactory);
         try {
@@ -26,7 +27,7 @@ public class DeleteFavoriteRecipeInteractorTest {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        User user1 = userFactory.create("Janis", "joplin", "Jantod", 38, "Man", 190, 78);
+        User user1 = userFactory.create("Janis", "joplin", "Jantod", 38, "Man", 190, 78, plannerFactory.create("Janis"));
         userDataAccessObject.save(user1);
 
         Recipe recipe = new Recipe("Asian-Style Chicken and Rice",
@@ -59,6 +60,7 @@ public class DeleteFavoriteRecipeInteractorTest {
         RecipeFactory recipeFactory = new RecipeFactory();
         FileRecipeDataAccessObject recipeDataAccessObject;
         DeleteFavoriteRecipeDataAccessInterface userDataAccessObject;
+        PlannerFactory plannerFactory = new PlannerFactory();
 
         recipeDataAccessObject = new FileRecipeDataAccessObject(recipeFactory);
         try {
@@ -66,7 +68,7 @@ public class DeleteFavoriteRecipeInteractorTest {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        User user1 = userFactory.create("Janis", "joplin", "Jantod", 38, "Man", 90, 168);
+        User user1 = userFactory.create("Janis", "joplin", "Jantod", 38, "Man", 90, 168, plannerFactory.create("Janis"));
         userDataAccessObject.save(user1);
 
         Recipe recipe = new Recipe("Indomie Goreng","github.com/ChristofferTan/csc207-project","github.com/elidle",350,new ArrayList<String>(Arrays.asList("1 bungkus Indomie Goreng")),5,1);

--- a/test/use_case/edit_profile/EditProfileInteractorTest.java
+++ b/test/use_case/edit_profile/EditProfileInteractorTest.java
@@ -3,6 +3,7 @@ package use_case.edit_profile;
 import data_access.FileUserDataAccessObject;
 import data_access.InMemoryUserDataAccessObject;
 import entity.CommonUserFactory;
+import entity.PlannerFactory;
 import entity.User;
 import entity.UserFactory;
 import org.junit.jupiter.api.Test;
@@ -17,13 +18,14 @@ public class EditProfileInteractorTest {
         EditProfileInputData inputData = new EditProfileInputData("RazanAr", "Razan", 17, "Male", 180, 77);
         EditProfileDataAccessInterface userRepository;
         UserFactory factory = new CommonUserFactory();
+        PlannerFactory plannerFactory = new PlannerFactory();
         try {
             userRepository = new FileUserDataAccessObject(factory);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
 
-        User user = factory.create("RazanAr", "admin", "Nazar", 71, "Female", 190, 49);
+        User user = factory.create("RazanAr", "admin", "Nazar", 71, "Female", 190, 49, plannerFactory.create("RazanAr"));
         userRepository.save(user);
         EditProfileOutputBoundary successPresenter = new EditProfileOutputBoundary() {
 

--- a/test/use_case/login/LoginInteractorTest.java
+++ b/test/use_case/login/LoginInteractorTest.java
@@ -2,6 +2,7 @@ package use_case.login;
 
 import data_access.FileUserDataAccessObject;
 import entity.CommonUserFactory;
+import entity.PlannerFactory;
 import entity.User;
 import entity.UserFactory;
 import org.junit.jupiter.api.Test;
@@ -16,12 +17,13 @@ public class LoginInteractorTest {
     void successTest() {
         UserFactory userFactory = new CommonUserFactory();
         LoginUserDataAccessInterface userDAO;
+        PlannerFactory plannerFactory = new PlannerFactory();
         try {
             userDAO = new FileUserDataAccessObject(userFactory);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        User user1 = userFactory.create("Budi", "pekerti", "Budiman", 58, "Man", 91, 150);
+        User user1 = userFactory.create("Budi", "pekerti", "Budiman", 58, "Man", 91, 150, plannerFactory.create("Budi"));
         userDAO.save(user1);
 
         LoginInputData inputData = new LoginInputData("Budi", "pekerti");

--- a/test/use_case/my_favorite_recipe/MyFavoriteRecipeInteractorTest.java
+++ b/test/use_case/my_favorite_recipe/MyFavoriteRecipeInteractorTest.java
@@ -21,6 +21,7 @@ public class MyFavoriteRecipeInteractorTest {
         RecipeFactory recipeFactory = new RecipeFactory();
         FileRecipeDataAccessObject recipeDAO;
         MyFavoriteRecipeDataAccessInterface userDAO;
+        PlannerFactory plannerFactory = new PlannerFactory();
 
         try {
             recipeDAO = new FileRecipeDataAccessObject(recipeFactory);
@@ -29,7 +30,7 @@ public class MyFavoriteRecipeInteractorTest {
             throw new RuntimeException(e);
         }
 
-        User user = userFactory.create("RazanAr", "admin", "Razan", 17, "Male", 70, 177);
+        User user = userFactory.create("RazanAr", "admin", "Razan", 17, "Male", 70, 177, plannerFactory.create("RazanAr"));
         ((FileUserDataAccessObject) userDAO).save(user);
         Recipe recipe = recipeFactory.create("Indomie Goreng", "github.com/ChristofferTan/csc207-project",
                 "github.com/elidle", 350, new ArrayList<String>(Arrays.asList("1 bungkus Indomie Goreng")),

--- a/test/use_case/myprofile/MyProfileInteractorTest.java
+++ b/test/use_case/myprofile/MyProfileInteractorTest.java
@@ -1,10 +1,7 @@
 package use_case.myprofile;
 
 import data_access.InMemoryUserDataAccessObject;
-import entity.CommonUser;
-import entity.CommonUserFactory;
-import entity.User;
-import entity.UserFactory;
+import entity.*;
 import org.junit.jupiter.api.Test;
 import use_case.signup.SignupInputData;
 
@@ -17,7 +14,8 @@ public class MyProfileInteractorTest {
         MyProfileDataAccessInterface userRepository = new InMemoryUserDataAccessObject();
 
         UserFactory factory = new CommonUserFactory();
-        User user = factory.create("faraaz", "Passw", "Faraaz", 19, "Man", 170, 60);
+        PlannerFactory plannerFactory = new PlannerFactory();
+        User user = factory.create("faraaz", "Passw", "Faraaz", 19, "Man", 170, 60, plannerFactory.create("faraaz"));
         ((InMemoryUserDataAccessObject) userRepository).save(user);
 
         MyProfileOutputBoundary successPresenter = new MyProfileOutputBoundary() {


### PR DESCRIPTION
- Modified `MealType`'s logic, now we can get the correct enum `MealType` when calling `fromString`.
- Changed some codes in the tests so that it is consistent with how we call `UserFactory` (need one more parameter i.e. `Planner`).
- Made a big test (`GenerateRecipeTest`) testing `GenerateRecipe`'s controller, interactor, DAO, and presenter