### PR TITLE
Username error message in login view fix

### DIFF
--- a/src/view/LoginView.java
+++ b/src/view/LoginView.java
@@ -134,6 +134,7 @@ public class LoginView extends JPanel implements ActionListener, PropertyChangeL
         LoginState state = (LoginState) evt.getNewValue();
         if (state.getUsernameError() != null) {
             JOptionPane.showMessageDialog(this, state.getUsernameError());
+            state.setUsernameError(null);
         }
 
         setFields(state);

--- a/src/view/SignupView.java
+++ b/src/view/SignupView.java
@@ -267,6 +267,7 @@ public class SignupView extends JPanel implements ActionListener, PropertyChange
         SignupState state = (SignupState) evt.getNewValue();
         if (state.getUsernameError() != null) {
             JOptionPane.showMessageDialog(this, state.getUsernameError());
+            state.setUsernameError(null);
         }
     }
 


### PR DESCRIPTION
When attempting to log in with a username that does not exist, the system displays a "Account does not exist: `username`" error message. However, upon signing in a new user, the same error message incorrectly shows up again. This small fix updates the view so that the error message is cleared upon being displayed.