### PR TITLE
Refactor: Apply dependency injection for API and file storage and rename file

### DIFF
--- a/src/api/edamam/GenerateRecipeAPICaller.java
+++ b/src/api/edamam/GenerateRecipeAPICaller.java
@@ -5,14 +5,13 @@ import okhttp3.*;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import use_case.generate_recipe.GenerateRecipeAPICallerInterface;
 import use_case.generate_recipe.GenerateRecipeInputData;
 
 import java.io.IOException;
 import java.util.ArrayList;
 
-public class GenerateRecipeAPICaller {
-    private GenerateRecipeAPICaller() {}
-
+public class GenerateRecipeAPICaller implements GenerateRecipeAPICallerInterface {
     private static final String API_URL = "https://api.edamam.com/api/recipes/v2";
     private static final String APP_ID = "97884852";
     private static final String APP_KEY = "29ec3f53238d1c6ec3c16c6412bc91ea";
@@ -20,15 +19,14 @@ public class GenerateRecipeAPICaller {
 
     /**
      * Used in GenerateRecipeInteractor, to generate a recipe based on the user's input
-     * @param inputData
+     * @param inputData the user's input
      * @return GenerateRecipeAPIData with a generated recipe inside it
      */
-    public static GenerateRecipeAPIData call(GenerateRecipeInputData inputData) {
+    public GenerateRecipeAPIData call(GenerateRecipeInputData inputData) {
         final RecipeFactory recipeFactory = new RecipeFactory();
 
         OkHttpClient client = new OkHttpClient().newBuilder().build();
         String type = "public";
-        MediaType mediaType = MediaType.parse("application/json");
 
         StringBuilder requestUrl = new StringBuilder(API_URL + "?type=" + type + "&app_id=" + APP_ID + "&app_key=" + APP_KEY);
         requestUrl.append("&q=").append(inputData.getQ());

--- a/src/api/file/io/FileIOFacade.java
+++ b/src/api/file/io/FileIOFacade.java
@@ -1,0 +1,19 @@
+package api.file.io;
+
+import data_access.OnlineFileStorageManager;
+
+import java.util.HashMap;
+
+public class FileIOFacade implements OnlineFileStorageManager {
+    public String download(String link) {
+        return DownloadCSVFilesAPICaller.call(link);
+    }
+
+    public HashMap<String, String> getFileList() {
+        return GetListofCSVFilesAPICaller.call();
+    }
+
+    public String upload(String filepath) {
+        return UploadCSVFilesAPICaller.call(filepath);
+    }
+}

--- a/src/data_access/OnlineFileStorageManager.java
+++ b/src/data_access/OnlineFileStorageManager.java
@@ -1,0 +1,9 @@
+package data_access;
+
+import java.util.HashMap;
+
+public interface OnlineFileStorageManager {
+    String download(String link);
+    HashMap<String, String> getFileList();
+    String upload(String filepath);
+}

--- a/src/use_case/generate_recipe/GenerateRecipeAPICallerInterface.java
+++ b/src/use_case/generate_recipe/GenerateRecipeAPICallerInterface.java
@@ -1,0 +1,7 @@
+package use_case.generate_recipe;
+
+import api.edamam.GenerateRecipeAPIData;
+
+public interface GenerateRecipeAPICallerInterface {
+    GenerateRecipeAPIData call(GenerateRecipeInputData inputData);
+}

--- a/src/use_case/generate_recipe/GenerateRecipeInteractor.java
+++ b/src/use_case/generate_recipe/GenerateRecipeInteractor.java
@@ -16,7 +16,8 @@ public class GenerateRecipeInteractor implements GenerateRecipeInputBoundary {
 
     @Override
     public void execute(GenerateRecipeInputData generateRecipeInputData) {
-        GenerateRecipeAPIData recipeAPIData = GenerateRecipeAPICaller.call(generateRecipeInputData);
+        GenerateRecipeAPICallerInterface generateRecipeAPICaller = new GenerateRecipeAPICaller();
+        GenerateRecipeAPIData recipeAPIData = generateRecipeAPICaller.call(generateRecipeInputData);
         if (recipeAPIData == null) {
             generateRecipePresenter.prepareFailView("There is no recipe based on your preferences");
         }

--- a/test/api/file/io/FileIOTest.java
+++ b/test/api/file/io/FileIOTest.java
@@ -1,12 +1,15 @@
 package api.file.io;
 
+import data_access.OnlineFileStorageManager;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.HashMap;
 
-public class fileIOTest {
+public class FileIOTest {
+    private final OnlineFileStorageManager onlineFileStorageManager = new FileIOFacade();
     private void writeToCSV(String content, String path) {
         BufferedWriter writer;
         try {
@@ -27,8 +30,8 @@ public class fileIOTest {
         final String filePath = "test/api/file/io/" + fileName;
         String expectedCSVContent = "tast,1\ntest,2\ntist,3";
         writeToCSV(expectedCSVContent, filePath);
-        String expectedLink = UploadCSVFilesAPICaller.call(filePath);
-        HashMap<String,String> actualListOfCSVFiles = GetListofCSVFilesAPICaller.call();
+        String expectedLink = onlineFileStorageManager.upload(filePath);
+        HashMap<String,String> actualListOfCSVFiles = onlineFileStorageManager.getFileList();
         // check if the file is in the list of files
         System.out.println("List of files name: " + actualListOfCSVFiles);
         assert actualListOfCSVFiles.containsKey(fileName);
@@ -37,7 +40,7 @@ public class fileIOTest {
         System.out.println("Link to the file: " + actualLink);
         assert actualLink.equals(expectedLink);
         // check if the content is correct)
-        String actualCSVContent = DownloadCSVFilesAPICaller.call(expectedLink);
+        String actualCSVContent = onlineFileStorageManager.download(expectedLink);
         System.out.println("Content of the file: " + actualCSVContent);
         assert actualCSVContent.equals(expectedCSVContent);
     }

--- a/test/data_access/FileDataAccessObjectTest.java
+++ b/test/data_access/FileDataAccessObjectTest.java
@@ -4,6 +4,7 @@ import api.edamam.GenerateRecipeAPICaller;
 import entity.MealType;
 import entity.Recipe;
 import entity.RecipeFactory;
+import use_case.generate_recipe.GenerateRecipeAPICallerInterface;
 import use_case.generate_recipe.GenerateRecipeInputData;
 
 import java.util.ArrayList;
@@ -17,7 +18,8 @@ public class FileDataAccessObjectTest {
                 new String[]{MealType.LUNCH.toString()},
                 "0-1000",
                 "0-100");
-        return GenerateRecipeAPICaller.call(generateRecipeInputData).getRecipe();
+        GenerateRecipeAPICallerInterface generateRecipeAPICaller = new GenerateRecipeAPICaller();
+        return generateRecipeAPICaller.call(generateRecipeInputData).getRecipe();
     }
 
     @org.junit.Test

--- a/test/interface_adapters/generate_recipe/GenerateRecipeTest.java
+++ b/test/interface_adapters/generate_recipe/GenerateRecipeTest.java
@@ -10,6 +10,7 @@ import interface_adapters.after_generated_recipe.AfterGeneratedRecipeViewModel;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import use_case.generate_recipe.GenerateRecipeAPICallerInterface;
 import use_case.generate_recipe.GenerateRecipeDataAccessInterface;
 import use_case.generate_recipe.GenerateRecipeInputData;
 
@@ -81,7 +82,8 @@ public class GenerateRecipeTest {
         String maxCalories = "1000";
         String maxPreparationTime = "100";
 
-        Recipe generatedRecipe = GenerateRecipeAPICaller.call(new GenerateRecipeInputData(q, diet, health, cuisineType, mealType, minCalories + "-" + maxCalories, "0-" + maxPreparationTime)).getRecipe();
+        GenerateRecipeAPICallerInterface generateRecipeAPICaller = new GenerateRecipeAPICaller();
+        Recipe generatedRecipe = generateRecipeAPICaller.call(new GenerateRecipeInputData(q, diet, health, cuisineType, mealType, minCalories + "-" + maxCalories, "0-" + maxPreparationTime)).getRecipe();
         recipeDAO.save(generatedRecipe);
 
         // check that the recipe saved is correct

--- a/test/view/SaveRecipeTest.java
+++ b/test/view/SaveRecipeTest.java
@@ -11,6 +11,7 @@ import entity.RecipeFactory;
 import interface_adapters.ViewManagerModel;
 import interface_adapters.save_recipe.SaveRecipeController;
 import interface_adapters.save_recipe.SaveRecipeViewModel;
+import use_case.generate_recipe.GenerateRecipeAPICallerInterface;
 import use_case.generate_recipe.GenerateRecipeInputData;
 
 import java.time.DayOfWeek;
@@ -34,7 +35,8 @@ public class SaveRecipeTest {
                 "100-1000",
                 "0-100"
         );
-        Recipe expectedRecipe = GenerateRecipeAPICaller.call(generateRecipeInputData).getRecipe();
+        GenerateRecipeAPICallerInterface generateRecipeAPICaller = new GenerateRecipeAPICaller();
+        Recipe expectedRecipe = generateRecipeAPICaller.call(generateRecipeInputData).getRecipe();
         saveRecipeController.execute("budi", DayOfWeek.MONDAY, MealType.LUNCH, expectedRecipe);
         Recipe actualRecipe = fpdao.getPlanner("budi").getRecipesByDay(DayOfWeek.MONDAY).get(MealType.LUNCH);
         assert expectedRecipe == actualRecipe;


### PR DESCRIPTION
- Implement dependency injection to decouple classes from specific API and file storage implementations.
- Introduce `GenerateRecipeAPICallerInterface` for recipe generation and `OnlineFileStorageManager` for database file operations. 

This change removes direct dependencies, offering flexibility to switch strategies for generating recipes or managing files in the database.
- Rename `fileIOTest.java` to `FileIOTest.java.`